### PR TITLE
Fix the date of the SoCraMOB event

### DIFF
--- a/phpugms_greeting_2019-01/index.html
+++ b/phpugms_greeting_2019-01/index.html
@@ -186,7 +186,7 @@
                 <section class="l-2up">
                     <h2>SoCraMOB 2019-1</h2>
 
-                    <p><strong>Saturday</strong>, March 19, 2019</p>
+                    <p><strong>Saturday</strong>, March 16, 2019</p>
 
                     <p>
                         Hellmann Worldwide Logistics <br/>

--- a/phpugms_greeting_2019-02/index.html
+++ b/phpugms_greeting_2019-02/index.html
@@ -169,7 +169,7 @@
         <section class="l-2up">
             <h2>SoCraMOB 2019-1</h2>
 
-            <p><strong>Saturday</strong>, March 19, 2019</p>
+            <p><strong>Saturday</strong>, March 16, 2019</p>
 
             <p>
                 Hellmann Worldwide Logistics <br/>


### PR DESCRIPTION
Slides shows "March 19". Is on "March 16".
See: https://www.softwerkskammer.org/activities/socramob-2019-1